### PR TITLE
Fix variable number of TLS pages in EEID

### DIFF
--- a/common/sgx/eeid.c
+++ b/common/sgx/eeid.c
@@ -508,7 +508,8 @@ size_t oe_eeid_byte_size(const oe_eeid_t* eeid)
     return sizeof(eeid->version) + sizeof(eeid->hash_state) +
            sizeof(eeid->signature_size) + sizeof(eeid->size_settings) +
            sizeof(eeid->vaddr) + sizeof(eeid->entry_point) +
-           sizeof(eeid->data_size) + eeid->data_size + eeid->signature_size;
+           sizeof(eeid->num_tls_pages) + sizeof(eeid->data_size) +
+           eeid->data_size + eeid->signature_size;
 }
 
 oe_result_t oe_eeid_hton(
@@ -542,6 +543,7 @@ oe_result_t oe_eeid_hton(
 
     OE_CHECK(_hton_uint64_t(eeid->vaddr, &position, &remaining));
     OE_CHECK(_hton_uint64_t(eeid->entry_point, &position, &remaining));
+    OE_CHECK(_hton_uint64_t(eeid->num_tls_pages, &position, &remaining));
 
     OE_CHECK(_hton_uint64_t(eeid->data_size, &position, &remaining));
     OE_CHECK(_hton_buffer(
@@ -588,6 +590,7 @@ oe_result_t oe_eeid_ntoh(
 
     OE_CHECK(_ntoh_uint64_t(&position, &remaining, &eeid->vaddr));
     OE_CHECK(_ntoh_uint64_t(&position, &remaining, &eeid->entry_point));
+    OE_CHECK(_ntoh_uint64_t(&position, &remaining, &eeid->num_tls_pages));
 
     OE_CHECK(_ntoh_uint64_t(&position, &remaining, &eeid->data_size));
     OE_CHECK(_ntoh_buffer(

--- a/tests/eeid_plugin/test_helpers.c
+++ b/tests/eeid_plugin/test_helpers.c
@@ -27,6 +27,7 @@ oe_result_t make_test_eeid(oe_eeid_t** eeid, size_t data_size)
     (*eeid)->size_settings.num_heap_pages = 110 + (data_size / OE_PAGE_SIZE);
     (*eeid)->size_settings.num_stack_pages = 50;
     (*eeid)->size_settings.num_tcs = 2;
+    (*eeid)->num_tls_pages = 1;
 
     result = OE_OK;
 


### PR DESCRIPTION
Just a couple of fixes for the EEID code. After building with `-DWITH_EEID=ON` you can run `ctest -VV -R tests/eeid_plugin` and it should pass.